### PR TITLE
fixed websocket validate to cope with multiple 'Connection' headers

### DIFF
--- a/modules/websocket/websocket.tcl
+++ b/modules/websocket/websocket.tcl
@@ -377,9 +377,6 @@ proc ::websocket::validate {hdrs} {
 			break
 		    }
 		}
-		if {!$upgrading} {
-		    ThrowError "No 'Connect' header with 'upgrade' token found" HANDSHAKE CONNECTION
-		}
 	    }
 	    upgrade {
 		# May be a list, see
@@ -432,6 +429,10 @@ proc ::websocket::validate {hdrs} {
 		dict lappend res protocols {*}$protocols;
 	    }
 	}
+    }
+
+    if {!$upgrading} {
+        ThrowError "No 'Connect' header with 'upgrade' token found" HANDSHAKE CONNECTION
     }
     if {![dict exists $res version]} {
 	ThrowError "No WebSocket version specified" HANDSHAKE VERSION


### PR DESCRIPTION
and still get the 'upgrade' value

When the 'Connection' Header appears multiple times and the first value is not "upgrade" (but keep-alive, for instance), the websocket::validate proc fails. This fix handles the issue.


Hello. __Attention please__

You are currently using the github __mirror__ of the Tcllib sources.

This is __not__ the location where Tcllib development takes place.

We are __not tracking issues entered here__. With the exception of the
maintainer of the mirroring setup nobody will even see such issues.

Please go to the
[official location of the sources](https://core.tcl-lang.org/tcllib)
and enter your ticket into the
[official ticket tracker](https://core.tcl-lang.org/tcllib/reportlist)
instead.

Thank you for your consideration.
